### PR TITLE
Feature/sm version tags

### DIFF
--- a/recipe.txt
+++ b/recipe.txt
@@ -1,9 +1,7 @@
-Docker=feature/recipe
-SetupLogging=feature/recipe
+Docker=v1.0.0
+SetupLogging=v1.1.0
 
-MQTTBroker=feature/recipe
-Timeseries=feature/recipe
-# AWSRelay=feature/recipe
-
-Grafana=feature/recipe
+MQTTBroker=v1.0.0
+Timeseries=v1.0.0
+Grafana=v1.0.0
 Sensing=feature/recipe-lite

--- a/recipe.txt
+++ b/recipe.txt
@@ -4,4 +4,4 @@ SetupLogging=v1.1.0
 MQTTBroker=v1.0.0
 Timeseries=v1.0.0
 Grafana=v1.0.0
-Sensing=feature/recipe-lite
+Sensing=lite-v0.1.0


### PR DESCRIPTION
Better version control by having the recipe point to tags instead of branch heads.
Particularly needed as the `feature/recipe` branches in the service modules are being merged into `main` and deleted.