### PR TITLE
Remove retention of sensor class instances

### DIFF
--- a/UserConfig/Sensing/main.py
+++ b/UserConfig/Sensing/main.py
@@ -6,11 +6,8 @@ from utilities.mqtt_out import publish
 from hardware.ICs.sht40 import SHT40
 from hardware.ICs.bmp280_wrapper import BMP280
 
-# setup sensors and models
-mysht40 = SHT40()
-mybmp280 = BMP280()
-
 # sensing loop
 while True:
     sleep(1)
-    publish( {"machine": "MachineNameHere"} | mysht40.get_TRH() | mybmp280.get_P() )
+    publish( {"machine": "MachineNameHere"} | SHT40.get_TRH() | BMP280.get_P() )
+    


### PR DESCRIPTION
Here's a simpler way of approaching issue 7: force re-init of the sensor ICs on each sample by not saving the class instance.

Call data aquisition class method directly, which in turn call `__init__`. A new class instance will be used on each cycle, loading in its calibration values afresh.